### PR TITLE
Refactor Docker image naming and update image metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,9 +42,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Get version number
+        id: version
+        run: echo "::set-output name=version::$(git rev-list --count HEAD)"
+
       - name: Build Docker image
         run: |
-          docker build -t ${{ secrets.DOCKER_HUB_USERNAME }}/stockdog:alpha-${{ github.sha  }} .
+          docker build -t ${{ secrets.DOCKER_HUB_USERNAME }}/stockdog:alpha-${{ steps.version.outputs.version  }} .
 
       - name: Login to DockerHub
         uses: docker/login-action@v3
@@ -53,17 +57,17 @@ jobs:
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
       - name: Push Docker image
-        run: docker push ${{ secrets.DOCKER_HUB_USERNAME }}/stockdog:alpha-${{ github.sha }}
+        run: docker push ${{ secrets.DOCKER_HUB_USERNAME }}/stockdog:alpha-${{ steps.version.outputs.version }}
 
       - name: Update image metadata
         uses: docker/metadata-action@v5
         with:
-          images: ${{ secrets.DOCKER_HUB_USERNAME }}/stockdog:alpha-${{ github.sha }}
+          images: ${{ secrets.DOCKER_HUB_USERNAME }}/stockdog:alpha-${{ steps.version.outputs.version }}
           tags: |
             type=sha
           labels: |
             org.opencontainers.image.title=StockDog App
             org.opencontainers.image.description=Stock market analysis app
             org.opencontainers.image.url=https://github.com/${{github.repository}}
-            org.opencontainers.image.revision=${{github.sha}}
+            org.opencontainers.image.revision=${{steps.version.outputs.version}}
             org.opencontainers.image.licenses=MIT


### PR DESCRIPTION
This pull request refactors the Docker image naming in the CI workflow and updates the image metadata to include the version number. The version number is obtained using the `git rev-list --count HEAD` command. This ensures that the Docker image is tagged with the correct version and the image metadata reflects the updated version.

Fixes the issue: [#13](https://github.com/danishjoseph/stockdog/issues/13)